### PR TITLE
exclude clojure.core/get from client to remove compile time warning

### DIFF
--- a/src/trello/client.clj
+++ b/src/trello/client.clj
@@ -4,7 +4,8 @@
    [clj-http.client :as client]
    [trello.core :refer [consumer *oauth-token* *oauth-secret*]]
    [oauth.client :as oauth]
-   [clojure.data.json :as json]))
+   [clojure.data.json :as json])
+  (:refer-clojure :exclude [get]))
 
 ;; prevent these from blowing up the type checker
 (ann ^:no-check clj-http.client/get [Any * -> Any])


### PR DESCRIPTION
John - for JNET... this is another error we are getting.  Not sure what changes you made - did not see commits here.